### PR TITLE
Ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.asv
 *~
 doc_C++/
+.DS_Store


### PR DESCRIPTION
## What
Add `.DS_Store` to `.gitignore`.

## Why
The current ignore-all-then-allow-extensions rule (`*` followed by `!*.*`) re-includes `.DS_Store`, so macOS Finder metadata files were trackable. Verified with `git check-ignore`:

- **before:** not ignored (would be committed)
- **after:** ignored at any depth

## Risk
Config-only change. No C++/MATLAB source, `Makefile`, or test files are touched, so the build and tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
