### PR TITLE
Ignore Windows Thumbs.db files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *~
 doc_C++/
 .DS_Store
+Thumbs.db


### PR DESCRIPTION
## What
Add `Thumbs.db` to `.gitignore` (mirrors the recent `.DS_Store` entry).

## Why
The ignore-all-then-allow-extensions rule (`*` then `!*.*`) re-includes `Thumbs.db`, so Windows thumbnail-cache files were trackable. Verified with `git check-ignore`: not ignored before, ignored at any depth after.

## Risk
Config-only change. No source, Makefile, or test files touched, so the build and tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)