### PR TITLE
Remove redundant #pragma once from utils.h

### DIFF
--- a/mole_C++/utils.h
+++ b/mole_C++/utils.h
@@ -9,8 +9,6 @@
  *
  */
 
-#pragma once
-
 #ifndef UTILS_H
 #define UTILS_H
 


### PR DESCRIPTION
## Summary

`utils.h` was the only header in `mole_C++/` carrying **both** `#pragma once` and the classic `#ifndef UTILS_H` include guard. The other 9 headers (curl, divergence, gradient, interpol, laplacian, mixedbc, mole, operators, robinbc) use only the `#ifndef` guard.

This drops the redundant `#pragma once` so all headers use the same guard style. No functional change — every header remains protected against multiple inclusion, and the guard macros are all unique.

```diff
-#pragma once
-
 #ifndef UTILS_H
 #define UTILS_H
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)