### PR TITLE
Fix README comma splice and fill empty Doxygen @brief fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Or simply:
 if _Armadillo_ was installed via `sudo apt install libarmadillo-dev` or `sudo yum install armadillo-devel`.
 
 A static library named `libmole.a` will be created after the previous step. From this point, you need to include `mole.h` 
-in your projects, specify the location of `libmole.a` to the linker. For the users interested in building MOLE as a _shared library_, specify `make SHARED_LIB=1`. Make sure to include `mole_C++` directory in `LD_LIBRARY_PATH` (`export LD_LIBRARY_PATH=/full/path/to/mole_C++`) so the loader can find the library at runtime.
+in your projects and specify the location of `libmole.a` to the linker. For the users interested in building MOLE as a _shared library_, specify `make SHARED_LIB=1`. Make sure to include `mole_C++` directory in `LD_LIBRARY_PATH` (`export LD_LIBRARY_PATH=/full/path/to/mole_C++`) so the loader can find the library at runtime.
 
 **For our library's MATLAB/Octave version, the only dependency is to have MATLAB/Octave installed**.
 The two implementations of MOLE (C++ & MATLAB/Octave) are independent; you don't need

--- a/mole_C++/mole.h
+++ b/mole_C++/mole.h
@@ -1,7 +1,7 @@
 /**
  * @file mole.h
  * @author Johnny Corbino (johnnycorbino@gmail.com)
- * @brief 
+ * @brief Umbrella header including all MOLE operators
  * @version 0.1
  * @date 2024-05-25
  * 

--- a/mole_C++/utils.h
+++ b/mole_C++/utils.h
@@ -1,7 +1,7 @@
 /**
  * @file utils.h
  * @author Johnny Corbino (johnnycorbino@gmail.com)
- * @brief
+ * @brief Sparse-matrix utility helpers
  * @version 0.1
  * @date 2024-05-26
  *


### PR DESCRIPTION
## Summary

Two small docs/consistency fixes:

1. **README** — fixed a comma splice in the install section: *"…include `mole.h` in your projects**,** specify the location of `libmole.a`…"* → *"…in your projects **and** specify the location…"*.
2. **Doxygen `@brief`** — `mole.h` and `utils.h` were the only C++ headers with an empty `@brief`. Filled them in so all headers document a brief:
   - `mole.h` → "Umbrella header including all MOLE operators"
   - `utils.h` → "Sparse-matrix utility helpers"

Docs/comments only — no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)